### PR TITLE
Give access to 'Add review' link based on user permissions

### DIFF
--- a/agency_review.features.user_permission.inc
+++ b/agency_review.features.user_permission.inc
@@ -14,7 +14,6 @@ function agency_review_user_default_permissions() {
   $permissions['create review content'] = array(
     'name' => 'create review content',
     'roles' => array(
-      'anonymous user' => 'anonymous user',
       'authenticated user' => 'authenticated user',
     ),
     'module' => 'node',

--- a/plugins/content_types/agency_button_unit_review.inc
+++ b/plugins/content_types/agency_button_unit_review.inc
@@ -20,7 +20,7 @@ $plugin = array(
 function agency_unit_review_button_render($subtype, $conf, $args, $pane_context, $incoming_content) {
   $content = '';
 
-  if (user_is_logged_in()) {
+  if (node_access('create', 'review')) {
     $link = l('Add Review', 'node/add/review', array('query' => array('property_id' => $args[0]), 'attributes' => array('class' => array('col-xs-12 col-sm-6 col-md-4 col-md-offset-8 col-sm-offset-6', 'agency-add-review'))));
     $content = '<div class="row">' . $link . '</div>';
   }


### PR DESCRIPTION
Currently you've a contradiction given you give access to anonymous users to create review nodes, however you only show the link to create new reviews to loggedin users using "user_is_logged_in()" function.

I proposing a pull request where access to that link is based on current user permissions and removing permission to create reviews to anonymous users.

This makes things more flexible and improves scalability.

Thanks